### PR TITLE
Use jenkins credentials

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,8 +19,9 @@ node('imf2public') {
                      bat '''
                     set TEMP=%WORKSPACE%
                     set TMP=%TEMP%
-                    
-                    %PYTHONPATH%python.exe ago-group-update.py -user %agouser% -pwd %agopassword% -group %group%
+                    set AGOPASSWORD=jenkins.model.Jenkins.instance.getCredentials().getById("d9d435e2-8acb-4698-bc74-2a1729472f1a").getPassword()
+		    
+                    %PYTHONPATH%python.exe ago-group-update.py -user %agouser% -pwd %AGOPASSWORD% -group %group%
                 '''
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,14 +16,16 @@ node('imf2public') {
 
 		stage("Copy Configs to the ${env.ENV} Server and run script to push data to ArcGIS Online") {
                 timeout(time: 20, unit: 'MINUTES') {
-                     bat '''
-                    set TEMP=%WORKSPACE%
-                    set TMP=%TEMP%
-                    set AGOPASSWORD=jenkins.model.Jenkins.instance.getCredentials().getById("d9d435e2-8acb-4698-bc74-2a1729472f1a").getPassword()
-		    echo %AGOPASSWORD%
-		    
-                    %PYTHONPATH%python.exe ago-group-update.py -user %agouser% -pwd %AGOPASSWORD% -group %group%
-                '''
+                    withCredentials([usernamePassword(credentialsId: 'd9d435e2-8acb-4698-bc74-2a1729472f1a', usernameVariable: 'AGOUSERNAME', passwordVariable: 'AGOPASSWORD')]) {
+			bat '''
+			    set TEMP=%WORKSPACE%
+			    set TMP=%TEMP%
+			    echo %AGOUSERNAME%
+			    echo %AGOPASSWORD%
+
+			    %PYTHONPATH%python.exe ago-group-update.py -user %agouser% -pwd %AGOPASSWORD% -group %group%
+                	'''
+		    }
             }
         }
     } 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,7 @@ node('imf2public') {
                     set TEMP=%WORKSPACE%
                     set TMP=%TEMP%
                     set AGOPASSWORD=jenkins.model.Jenkins.instance.getCredentials().getById("d9d435e2-8acb-4698-bc74-2a1729472f1a").getPassword()
+		    echo %AGOPASSWORD%
 		    
                     %PYTHONPATH%python.exe ago-group-update.py -user %agouser% -pwd %AGOPASSWORD% -group %group%
                 '''
@@ -34,11 +35,11 @@ node('imf2public') {
     }
 }
 
-def notifyFailed() {
-    emailext (
-        subject: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
-        body: """<html><body><p>FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]':</p>
-            <p>Check console output at "<a href="${env.BUILD_URL}">${env.JOB_NAME} [${env.BUILD_NUMBER}]</a>"</p></html></body>""",
-        to: 'datamaps@gov.bc.ca'
-    )
-}
+// def notifyFailed() {
+//     emailext (
+//         subject: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
+//         body: """<html><body><p>FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]':</p>
+//             <p>Check console output at "<a href="${env.BUILD_URL}">${env.JOB_NAME} [${env.BUILD_NUMBER}]</a>"</p></html></body>""",
+//         to: 'datamaps@gov.bc.ca'
+//     )
+// }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,8 +20,6 @@ node('imf2public') {
 			bat '''
 			    set TEMP=%WORKSPACE%
 			    set TMP=%TEMP%
-			    echo %AGOUSERNAME%
-			    echo %AGOPASSWORD%
 
 			    %PYTHONPATH%python.exe ago-group-update.py -user %agouser% -pwd %AGOPASSWORD% -group %group%
                 	'''
@@ -37,11 +35,11 @@ node('imf2public') {
     }
 }
 
-// def notifyFailed() {
-//     emailext (
-//         subject: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
-//         body: """<html><body><p>FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]':</p>
-//             <p>Check console output at "<a href="${env.BUILD_URL}">${env.JOB_NAME} [${env.BUILD_NUMBER}]</a>"</p></html></body>""",
-//         to: 'datamaps@gov.bc.ca'
-//     )
-// }
+def notifyFailed() {
+    emailext (
+        subject: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'",
+        body: """<html><body><p>FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]':</p>
+            <p>Check console output at "<a href="${env.BUILD_URL}">${env.JOB_NAME} [${env.BUILD_NUMBER}]</a>"</p></html></body>""",
+        to: 'datamaps@gov.bc.ca'
+    )
+}


### PR DESCRIPTION
Retrieve credentials stored in Jenkins with the credentials-binding plugin (already installed) rather than passing as a parameter (which outputs password as plain text to console)

Test build - https://cis.apps.gov.bc.ca/int/job/waops/job/AGO%20ALL_GOV%20Group%20Update/100/console